### PR TITLE
[condense] fix type error when building outfile

### DIFF
--- a/subs2cia/condense.py
+++ b/subs2cia/condense.py
@@ -190,7 +190,7 @@ class SubCondensed:
         if self.picked_streams['audio'] is None:
             logging.error(f'No audio stream to process for output stem {self.outstem}')
             return
-        outfile = self.outdir / (self.outstem + f'.{self.out_audioext}')
+        outfile = Path(self.outdir) / (self.outstem + f'.{self.out_audioext}')
         # logging.info(f"exporting condensed audio to {outfile}")  # todo: fix output naming
         if outfile.exists() and not self.overwrite_existing_generated:
             logging.warning(f"Can't write to {outfile}: file exists and not set to overwrite")


### PR DESCRIPTION
When running `subs2cia -i /somewhere/* -b -d /elsewhere/`,
got the following exception:
```
    Traceback (most recent call last):
      ...
      File "/xxx/python3.8/site-packages/subs2cia/condense.py", line 193, in export_audio
        outfile = self.outdir / (self.outstem + f'.{self.out_audioext}')
    TypeError: unsupported operand type(s) for /: 'str' and 'str'
```
Fixed it by building a `Path` out of the `self.outdir` string.