### PR TITLE
Can ignore chapters in addition to time ranges

### DIFF
--- a/subs2cia/Common.py
+++ b/subs2cia/Common.py
@@ -30,6 +30,11 @@ def insufficient_source_streams(d: dict):
     return False
 
 
+def chapter_timestamps(sourcefile: AVSFile, ignore_chapters: List[str]):
+    chapters = sourcefile.info['chapters'] or []
+    return [[('', 1000 * int(float((chapter['start_time'])))), ('', 1000 * int(float(chapter['end_time'])))]
+            for chapter in chapters if chapter['tags']['title'] in ignore_chapters]
+
 def interactive_picker(sources: List[AVSFile], partitioned_streams: Dict[str, Stream], media_type: str):
     print("Input files:")
     for avsf in sources:
@@ -66,8 +71,8 @@ class Common:
                  demux_overwrite_existing: bool, overwrite_existing_generated: bool,
                  keep_temporaries: bool, target_lang: str, out_audioext: str,
                  use_all_subs: bool, subtitle_regex_filter: str, audio_stream_index: int, subtitle_stream_index: int,
-                 ignore_range: Union[List[List[int]], None], bitrate: Union[int, None], mono_channel: bool,
-                 interactive: bool):
+                 ignore_range: Union[List[List[int]], None], ignore_chapters: Union[List[str], None],
+                 bitrate: Union[int, None], mono_channel: bool, interactive: bool):
         if outdir is None:
             self.outdir = sources[0].filepath.parent
         else:
@@ -113,6 +118,7 @@ class Common:
         self.subtitle_stream_index = subtitle_stream_index
         # todo: verify ignore_range, make sure start is after end
         self.ignore_range = ignore_range
+        self.ignore_chapters = ignore_chapters
 
         self.insufficient = False
 

--- a/subs2cia/Common.py
+++ b/subs2cia/Common.py
@@ -31,9 +31,25 @@ def insufficient_source_streams(d: dict):
 
 
 def chapter_timestamps(sourcefile: AVSFile, ignore_chapters: List[str]):
+    if len(ignore_chapters) == 0:
+        return []
+
     chapters = sourcefile.info['chapters'] or []
-    return [[('', 1000 * int(float((chapter['start_time'])))), ('', 1000 * int(float(chapter['end_time'])))]
-            for chapter in chapters if chapter['tags']['title'] in ignore_chapters]
+
+    if len(chapters) == 0:
+        return []
+
+    chapters_by_title = {c['tags']['title']: c for c in chapters}
+    timestamps = []
+
+    for title in ignore_chapters:
+        if title in chapters_by_title:
+            chapter = chapters_by_title[title]
+            timestamps.append([('', 1000 * int(float((chapter['start_time'])))), ('', 1000 * int(float(chapter['end_time'])))])
+        else:
+            logging.warning(f"Chapter '{title}' was specified to be ignored, but it was not found")
+
+    return timestamps
 
 def interactive_picker(sources: List[AVSFile], partitioned_streams: Dict[str, Stream], media_type: str):
     print("Input files:")

--- a/subs2cia/argparser.py
+++ b/subs2cia/argparser.py
@@ -160,7 +160,9 @@ def get_args_subs2cia():
                                     #     "\t-I -2m +1m30s  # ignore subtitles that exist in the first 1m30s of the last 2 minutes of audio"
                                  "If batch mode is enabled, the same ranges are applied to ALL outputs."
                                  "Multiple ranges can be specified like so: -I 2m 3m30s -I 20m 21m. ")
-
+    parent_parser.add_argument('-Ic', '--ignore-chapter', metavar="<chapter name>", dest="ignore_chapters", default=None,
+                            type=str, action="append",
+                            help="Chapters to ignore. Can be used in addition to --ignore-range to ignore sections of the stream.")
     parent_parser.add_argument('-p', '--padding', metavar='msecs', dest='padding', default=0,
                             type=int,
                             help='Adds this many milliseconds of audio before and after every subtitle. '

--- a/subs2cia/main.py
+++ b/subs2cia/main.py
@@ -45,8 +45,8 @@ def condense_start(args, groups: List[List[AVSFile]]):
                  ['outdir', 'outstem','condensed_video', 'padding', 'threshold', 'partition', 'split',
                   'demux_overwrite_existing', 'overwrite_existing_generated', 'keep_temporaries',
                   'target_lang', 'out_audioext', 'minimum_compression_ratio', 'use_all_subs', 'subtitle_regex_filter',
-                  'audio_stream_index', 'subtitle_stream_index', 'ignore_range', 'bitrate', 'mono_channel',
-                  'interactive']}
+                  'audio_stream_index', 'subtitle_stream_index', 'ignore_range', 'ignore_chapters',
+                  'bitrate', 'mono_channel', 'interactive']}
 
     condensed_files = [Condense(g, **condense_args) for g in groups]
     for c in condensed_files:
@@ -66,8 +66,8 @@ def srs_export_start(args, groups: List[List[AVSFile]]):
     srs_args = {key: args[key] for key in
                  ['outdir', 'outstem', 'condensed_video', 'padding', 'demux_overwrite_existing',
                   'overwrite_existing_generated', 'keep_temporaries', 'target_lang', 'out_audioext', 'use_all_subs',
-                  'subtitle_regex_filter', 'audio_stream_index', 'subtitle_stream_index', 'ignore_range', 'bitrate',
-                  'mono_channel', 'interactive', 'normalize_audio']
+                  'subtitle_regex_filter', 'audio_stream_index', 'subtitle_stream_index', 'ignore_range', 'ignore_chapters',
+                  'bitrate', 'mono_channel', 'interactive', 'normalize_audio']
                 }
 
     cardexport_group = [CardExport(g, **srs_args) for g in groups]

--- a/subs2cia/sources.py
+++ b/subs2cia/sources.py
@@ -25,7 +25,7 @@ class AVSFile:
     # but sometimes its better to use a parser and make sure the extension is correct
     def probe(self):
         try:
-            self.info = ffmpeg.probe(self.filepath, cmd='ffprobe')
+            self.info = ffmpeg.probe(self.filepath, 'ffprobe', **{'show_chapters': None})
         except ffmpeg.Error as e:
             logging.warning(
                 f"Couldn't probe file, skipping {str(self.filepath)}. ffmpeg output: \n" + e.stderr.decode("utf-8"))


### PR DESCRIPTION
I was attempting to extract audio from a TV show where the OP and ED was not in exactly the same time range every episode. These sections were however labeled as chapters in the MKV file. This diff allows these sections to be specified via chapter name and ignored using `--ignore-chapter`. The ignored chapters are converted into time ranges which are merged with the ranges provided by `--ignore-range` in `choose_subtitle`.