### PR TITLE
fix #22

### DIFF
--- a/subs2cia/condense.py
+++ b/subs2cia/condense.py
@@ -164,7 +164,7 @@ class Condense(Common):
 
         self.subtitle_outfile = Path(self.outdir) / (
                     self.outstem + f'.condensed{self.out_subext if self.out_subext is not None else subext}')
-        self.subdata.condensed_ssadata.save(self.subtitle_outfile, encoding=u'utf-8')
+        self.subdata.condensed_ssadata.save(str(self.subtitle_outfile), encoding=u'utf-8')
         logging.info(f"Wrote condensed subtitles to {self.subtitle_outfile}")
 
     def export_audio(self):


### PR DESCRIPTION
There was another case of `TypeError: expected str, bytes or os.PathLike object, not PosixPath`, which should be fixed now. 
Full export was working for me. Thanks again for the great tool!