### PR TITLE
Group by filename in batch mode

### DIFF
--- a/subs2cia/sources.py
+++ b/subs2cia/sources.py
@@ -214,7 +214,7 @@ def group_names_better(sources: List[AVSFile]) -> List[List[AVSFile]]:
         group = [sources.pop(0)]
         to_remove = []
         for f in sources:
-            if strip_extensions(f.filepath) == strip_extensions(group[0].filepath):
+            if strip_extensions(f.filepath).name == strip_extensions(group[0].filepath).name:
                 group.append(f)
                 to_remove.append(f)
         for f in to_remove:


### PR DESCRIPTION
There are cases where some users (like me) have configured their media player (such as [mpv](https://mpv.io/)) to look for subtitle files in a sub-directory to keep the base directory with all the videos clean. E.g. video is `./video.mkv` and subtitle file is located at `./subs/video.srt`. Everything still works in the original format where everything is in the same directory.