### PR TITLE
Add __pycache__ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build
-#/dist
 /*.egg-info
 /test
 /dist
+__pycache__
+


### PR DESCRIPTION
This PR adds `__pycache__` to `.gitignore`.

This was originally a part of PR #34 (which is now closed without merging) 
