### PR TITLE
Remove dependency on numpy and pandas, add more srs export arguments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,6 @@ pycountry>=19.8.18
 pysubs2>=1.1.0
 setuptools~=49.1.0
 tqdm>=4.51.0
-pandas>=1.1.4
 tqdm
 gevent
-pandas
 colorlog
-numpy

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setuptools.setup(
         "pycountry",
         "pysubs2",
         "tqdm",
-        "pandas", "tqdm", "gevent", "colorlog"
+        "tqdm", "gevent", "colorlog"
     ],
     entry_points={
         # create a cli command called 'subs2cia' which runs the main() function in subs2cia.cli

--- a/subs2cia/CardExport.py
+++ b/subs2cia/CardExport.py
@@ -5,9 +5,9 @@ from subs2cia.ffmpeg_tools import ffmpeg_trim_audio_clip_atrim_encode, ffmpeg_ge
 
 from typing import List, Union
 from pathlib import Path
+import csv
 import logging
 import tqdm
-import pandas as pd
 import unicodedata as ud
 from collections import defaultdict
 
@@ -20,7 +20,15 @@ class CardExport(Common):
                  # subtitle_regex_substrfilter_nokeep: bool,
                  audio_stream_index: int, subtitle_stream_index: int,
                  ignore_range: Union[List[List[int]], None], ignore_chapters: Union[List[str], None],
-                 bitrate: Union[int, None], mono_channel: bool, interactive: bool, normalize_audio: bool, out_audiocodec: str):
+                 bitrate: Union[int, None], mono_channel: bool, interactive: bool, out_audiocodec: str,
+
+                 normalize_audio: bool,
+                 media_dir: str|None,
+                 no_export_audio: bool,
+                 no_export_screenshot: bool,
+                 export_video: bool,
+                 export_header_row: bool,
+                 ):
         super(CardExport, self).__init__(
             sources=sources,
             outdir=outdir,
@@ -46,11 +54,18 @@ class CardExport(Common):
             out_audiocodec=out_audiocodec
         )
 
-        self.insufficient = False
-
         self.normalize_audio = normalize_audio
 
+        self.media_dir = media_dir
+        self.export_audio = not no_export_audio
+        self.export_screenshot = not no_export_screenshot
+        self.export_video = export_video
+        self.export_header_row = export_header_row
+
         self.subdata = None
+
+        # This is set to True later if there aren't any usable subtitles
+        self.insufficient = False
 
     def choose_subtitle(self, interactive):
         if len(self.partitioned_streams['subtitle']) == 0:
@@ -93,53 +108,115 @@ class CardExport(Common):
             self.subdata = subdata
 
     def export(self):
+
         # expose these as options at some point
         # will need to rename these if they are going to become cli switches so they don't conflict
         forbidden_chars = ['[' , ']' , '<' , '>' , ':' , '"' , '/' , '?' , '*' , '^' , '\\' , '|']  # see fn disallowed_char in https://github.com/ankitects/anki/blob/main/rslib/src/media/files.rs
         forbidden_chars = {ord(c): '' for c in forbidden_chars}
-        export_audio = True if self.picked_streams['audio'] is not None else False
-        export_screenshot = True if self.picked_streams['video'] is not None else False
-        export_video = False
-        lbda = 0.0  # where to get screenshot. 0=start, 1=end, 0.5=middle
-        w = -1
-        h = -1
-        columns = ['text', 'timestamps', 'audioclip', 'screenclip', 'videoclip', 'sources']
-        exported = pd.DataFrame(columns=columns)
-        for group in tqdm.tqdm(self.subdata.groups):
-            # since subdata.merge_groups hasn't been called, each group only contains one SSAevent
 
-            if group.contains_only_ephemeral:
-                continue
-            row = {'text': group.events[0].plaintext,
-                   'timestamps': f"{group.group_range[0]}-{group.group_range[1]}",
-                   'audioclip': None,
-                   'screenclip': None,
-                   'videoclip': None,
-                   'sources': ",".join([s.filepath.name for s in self.sources])}
-            if export_audio:
-                outpath = self.outdir / (ud.normalize('NFC', self.outstem).translate(forbidden_chars) + f"_{group.group_range[0]}-{group.group_range[1]}.mp3")
-                row['audioclip'] = f"[sound:{outpath.name}]"
-                ffmpeg_trim_audio_clip_atrim_encode(input_file=self.picked_streams['audio'].demux_file.filepath,
-                                                    stream_index=0,
-                                                    timestamp_start=group.group_range[0],
-                                                    timestamp_end=group.group_range[1], quality=self.quality,
-                                                    to_mono=self.to_mono, normalize_audio=self.normalize_audio,
-                                                    outpath=outpath)
-            if export_screenshot:
-                outpath = self.outdir / (ud.normalize('NFC', self.outstem).translate(forbidden_chars) + f"_{group.group_range[0]}-{group.group_range[1]}.jpg")
-                row['screenclip'] = f"<img src='{outpath.name}'>"
-                timestamp = (1-lbda) * group.group_range[0] + lbda * group.group_range[1]
-                ffmpeg_get_frame_fast(self.picked_streams['video'].file.filepath,
-                                      timestamp=timestamp, outpath=outpath, w=w, h=h)
-            if export_video:
-                outpath = self.outdir / (ud.normalize('NFC', self.outstem).translate(forbidden_chars) + f"_{group.group_range[0]}-{group.group_range[1]}.mp4")
-                row['videoclip'] = f"[sound:{outpath.name}]"
-                ffmpeg_trim_video_clip_directcopy(self.picked_streams['video'].file.filepath,
-                                                  timestamp_start=group.group_range[0],
-                                                    timestamp_end=group.group_range[1], quality=None, outpath=outpath)
-            exported = exported.append([row], ignore_index=True)
-            # if exported.shape[0] > 10:  # DEBUG ONLY
-            #     break
-        # print(exported)
-        outpath = self.outdir / (self.outstem + ".tsv")
-        exported.to_csv(outpath, sep='\t', index=False, header=False)
+        csv_columns = [
+            'text',
+            'timestamps',
+            'audioclip',
+            'screenclip',
+            'videoclip',
+            'sources',
+        ]
+
+        export_audio = self.export_audio and self.picked_streams['audio'] is not None
+        export_screenshot = self.export_screenshot and self.picked_streams['video'] is not None
+        export_video = self.export_video and self.picked_streams['video'] is not None
+        export_header_row = self.export_header_row
+
+        # path to write the csv (or tsv) file to
+        csv_outpath = self.outdir / (self.outstem + ".tsv")
+
+        # path to write media files to (exported screenshots, audio clips, video clips)
+        if self.media_dir is not None:
+            media_dir = Path(self.media_dir)
+        else:
+            media_dir = self.outdir
+
+        # where to get screenshot. 0=start, 1=end, 0.5=middle
+        lbda = 0.0  
+
+        # we only need to worry about creating the media dir if we are exporting any media
+        if export_audio or export_screenshot or export_video:
+            if not media_dir.exists():
+                media_dir.mkdir(exist_ok=True)
+            if not media_dir.is_dir():
+                raise RuntimeError(f"Not a directory: {media_dir}")
+
+
+        # for each group, write a row to the csv (tsv) file.
+        # as we go, export media files (screenshots, clips) as needed
+
+        with open(csv_outpath, 'w', encoding='utf-8', newline='') as f:
+
+            csvw = csv.writer(f, delimiter='\t')
+
+            if export_header_row:
+                csvw.writerow(csv_columns)
+
+            for group in tqdm.tqdm(self.subdata.groups):
+                # since subdata.merge_groups hasn't been called, each group only contains one SSAevent
+
+                if group.contains_only_ephemeral:
+                    continue
+
+                row = {
+                    'text': group.events[0].plaintext,
+                    'timestamps': f"{group.group_range[0]}-{group.group_range[1]}",
+                    'sources': ",".join([s.filepath.name for s in self.sources])
+                }
+
+                media_file_stem = media_dir / (ud.normalize('NFC', self.outstem).translate(forbidden_chars) + f"_{group.group_range[0]}-{group.group_range[1]}")
+
+                if export_audio:
+                    outpath = media_file_stem.with_suffix('.mp3')
+                    row['audioclip'] = f"[sound:{outpath.name}]"
+
+                    if outpath.exists():
+                        logging.warning(f"Already exists: {outpath}")
+                    else:
+                        ffmpeg_trim_audio_clip_atrim_encode(
+                            input_file=self.picked_streams['audio'].demux_file.filepath,
+                            stream_index=0,
+                            timestamp_start=group.group_range[0],
+                            timestamp_end=group.group_range[1],
+                            quality=self.quality,
+                            to_mono=self.to_mono,
+                            normalize_audio=self.normalize_audio,
+                            outpath=outpath
+                        )
+
+                if export_screenshot:
+                    outpath = media_file_stem.with_suffix('.jpg')
+                    row['screenclip'] = f"<img src='{outpath.name}'>"
+
+                    if outpath.exists():
+                        logging.info(f"Already exists: {outpath}")
+                    else:
+                        ffmpeg_get_frame_fast(
+                            self.picked_streams['video'].file.filepath,
+                            timestamp=(1-lbda) * group.group_range[0] + lbda * group.group_range[1],
+                            outpath=outpath,
+                            w=-1,
+                            h=-1
+                        )
+
+                if export_video:
+                    outpath = media_file_stem.with_suffix('.mp4')
+                    row['videoclip'] = f"[sound:{outpath.name}]"
+
+                    if outpath.exists():
+                        logging.info(f"Already exists: {outpath}")
+                    else:
+                        ffmpeg_trim_video_clip_directcopy(
+                            self.picked_streams['video'].file.filepath,
+                            timestamp_start=group.group_range[0],
+                            timestamp_end=group.group_range[1], quality=None, outpath=outpath
+                        )
+
+                csvw.writerow([row.get(col, '') for col in csv_columns])
+

--- a/subs2cia/argparser.py
+++ b/subs2cia/argparser.py
@@ -285,6 +285,25 @@ def get_args_subs2cia():
     cia_parser.add_argument('--no-gen-subtitle', action='store_true', dest='no_condensed_subtitles', default=False,
                             help="If set, won't output a condensed subtitle file. Useful for reducing file clutter.")
 
+    srs_parser.add_argument('--media-dir', metavar='/path/to/directory', dest='media_dir', default=None,
+                            type=str,
+                            help="Directory to save media files to. Defaults to the same as --output-dir. You might "
+                                 "set this to your Anki instance's media directory if your Anki doesn't automagically "
+                                 "import the media files alongside the TSV file.")
+
+    srs_parser.add_argument('--no-export-screenshot', action='store_true', dest='no_export_screenshot', default=False,
+                            help="If set, won't output screenshot files into the media folder.")
+
+    srs_parser.add_argument('--no-export-audio', action='store_true', dest='no_export_audio', default=False,
+                            help="If set, won't output audio files into the media folder.")
+
+    srs_parser.add_argument('--export-video', action='store_true', dest='export_video', default=False,
+                            help="If set, will output video files into the media folder.")
+
+    srs_parser.add_argument('--export-header-row', action='store_true', dest='export_header_row', default=False,
+                            help="If set, the resulting TSV file will have a header row which contains the column names. "
+                                 "This will make the file easier to read or reason about in a spreadsheet application, but "
+                                 "Anki will import the header row as a useless card.")
     args = parser.parse_args()
 
     # temporary patch until this feature is ready

--- a/subs2cia/main.py
+++ b/subs2cia/main.py
@@ -108,7 +108,16 @@ def srs_export_start(args, groups: List[List[AVSFile]]):
                  'overwrite_existing_generated', 'keep_temporaries', 'target_lang', 'out_audioext', 'use_all_subs',
                  'subtitle_regex_filter', 'audio_stream_index', 'subtitle_stream_index', 'ignore_range',
                  'ignore_chapters',
-                 'bitrate', 'mono_channel', 'interactive', 'normalize_audio', "out_audiocodec"]
+                 'bitrate', 'mono_channel', 'interactive', "out_audiocodec",
+
+                 'normalize_audio', 
+                 'media_dir',
+                 'no_export_screenshot',
+                 'no_export_audio',
+                 'export_video',
+                 'export_header_row',
+
+                 ]
                 }
 
     cardexport_group = [CardExport(g, **srs_args) for g in groups]


### PR DESCRIPTION
This PR rewrites the TSV export logic in `CardExport.py` to achieve the following effects:

- Uses Python's built in `csv` package
- Removes the dependency on `pandas` and `numpy`
- Allows for control over whether audio/video/screenshot are exported

The contents of this PR were originally included in PR #34.